### PR TITLE
fix order_image

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -51,6 +51,7 @@ class OrdersController < ApplicationController
         new_order_image = OrderImage.new
         new_order_image.order_id = new_order.id
         new_order_image.post_image_id = cart_image.post_image_id
+        new_order_image.image_id = PostImage.find(cart_image.post_image_id).image_id
         new_order_image.save
       end
       cart_images.destroy_all

--- a/app/models/order_image.rb
+++ b/app/models/order_image.rb
@@ -1,4 +1,5 @@
 class OrderImage < ApplicationRecord
+  attachment :image
   belongs_to :post_image
   belongs_to :order
 end

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -22,7 +22,7 @@
     <h4 class="form-title">ご注文写真</h4>
       <div class="cart-images-container">
         <% @order_images.each do |order_image| %>
-          <%= attachment_image_tag order_image.post_image, :image %>
+          <%= attachment_image_tag order_image, :image %>
         <% end %>
       </div>
     <h4 class="form-title">アルバム部数</h4>

--- a/db/migrate/20200820090610_create_order_images.rb
+++ b/db/migrate/20200820090610_create_order_images.rb
@@ -3,7 +3,7 @@ class CreateOrderImages < ActiveRecord::Migration[5.2]
     create_table :order_images do |t|
       t.integer :order_id, null: false
       t.integer :post_image_id, null: false
-
+      t.string :image_id, null: false
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 2020_08_20_090610) do
   create_table "order_images", force: :cascade do |t|
     t.integer "order_id", null: false
     t.integer "post_image_id", null: false
+    t.string "image_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
○注文写真の修正
・注文確定後、写真が削除されても履歴は残り続ける使用にするため、
　orderimagesテーブルにimage_idのカラムを追加。
・注文履歴詳細画面の修正